### PR TITLE
Fix filename to match electrum-xvg-tor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ data_files = []
 if platform.system() in [ 'Linux', 'FreeBSD', 'DragonFly']:
     usr_share = os.path.join(sys.prefix, "share")
     data_files += [
-        (os.path.join(usr_share, 'applications/'), ['electrum-xvg.desktop']),
+        (os.path.join(usr_share, 'applications/'), ['electrum-xvg-tor.desktop']),
         (os.path.join(usr_share, 'pixmaps/'), ['icons/electrum-xvg.png'])
     ]
 


### PR DESCRIPTION
Fix
error: can't copy 'electrum-xvg.desktop': doesn't exist or not a regular file