### PR TITLE
 Added chmod +x step for Linux users

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ pyrcc4 icons.qrc -o gui/qt/icons_rc.py
 
 sudo python setup.py install
 
+chmod +x ./electrum-xvg
+
 To run Electrum from this directory, just do:
 ---------------------------------------------
   ./electrum-xvg


### PR DESCRIPTION
Without this, trying to run electrum-xvg on Linux gives the error `bash: ./electrum-xvg: Permission denied`.